### PR TITLE
Refactor views into components

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,6 +10,11 @@ import GoogleCalendarService from './services/GoogleCalendarService';
 import Sidebar from './components/common/Sidebar';
 import EditTaskModal from './components/tasks/EditTaskModal';
 import EditEventModal from './components/events/EditEventModal';
+import Dashboard from './components/Dashboard';
+import WeeklyPlanner from './components/WeeklyPlanner';
+import TasksView from './components/TasksView';
+import ClaudeAssistant from './components/ClaudeAssistant';
+import Settings from './components/Settings';
 
 // Constants and utilities
 import { mockWorkouts, mockRecipes, localTasks } from './constants/mockData';
@@ -2120,15 +2125,77 @@ const LifeDashboardApp = () => {
   const renderContent = () => {
     switch(activeView) {
       case 'dashboard':
-        return renderDashboard();
+        return (
+          <Dashboard
+            selectedDate={selectedDate}
+            setSelectedDate={setSelectedDate}
+            showDatePicker={showDatePicker}
+            setShowDatePicker={setShowDatePicker}
+            tasks={tasks}
+            getTasksForDate={getTasksForDate}
+            scratchpadContent={scratchpadContent}
+            setScratchpadContent={setScratchpadContent}
+            handleTaskCompletionToggle={handleTaskCompletionToggle}
+          />
+        );
       case 'planner':
-        return renderWeeklyPlanner();
+        return (
+          <WeeklyPlanner
+            currentWeekStart={currentWeekStart}
+            navigateWeek={navigateWeek}
+            weekDates={weekDates}
+            getTasksForDate={getTasksForDate}
+          />
+        );
       case 'tasks':
-        return renderTasksView(); // New view for tasks
+        return (
+          <TasksView
+            tasks={tasks}
+            todoistToken={todoistToken}
+            loadingTodoistTasks={loadingTodoistTasks}
+            todoistError={todoistError}
+            fetchTodoistTasks={fetchTodoistTasks}
+            setShowAddTaskModal={setShowAddTaskModal}
+            showAddTaskModal={showAddTaskModal}
+            newTaskContent={newTaskContent}
+            setNewTaskContent={setNewTaskContent}
+            newTaskPriority={newTaskPriority}
+            setNewTaskPriority={setNewTaskPriority}
+            newTaskDueDate={newTaskDueDate}
+            setNewTaskDueDate={setNewTaskDueDate}
+            newTaskDueDateMode={newTaskDueDateMode}
+            setNewTaskDueDateMode={setNewTaskDueDateMode}
+            handleAddTask={handleAddTask}
+            handleDeleteTask={handleDeleteTask}
+            handleTaskCompletionToggle={handleTaskCompletionToggle}
+            setEditingTask={setEditingTask}
+            setShowEditTaskModal={setShowEditTaskModal}
+            activeFilters={activeFilters}
+            setActiveFilters={setActiveFilters}
+            sortBy={sortBy}
+            setSortBy={setSortBy}
+            groupBy={groupBy}
+            setGroupBy={setGroupBy}
+            selectedProjects={selectedProjects}
+            setSelectedProjects={setSelectedProjects}
+            availableProjects={availableProjects}
+          />
+        );
       case 'claude':
-        return renderClaudeAssistant();
+        return <ClaudeAssistant />;
       case 'settings':
-        return renderSettings();
+        return (
+          <Settings
+            todoistToken={todoistToken}
+            setTodoistToken={setTodoistToken}
+            handleSaveTodoistToken={handleSaveTodoistToken}
+            todoistError={todoistError}
+            googleCalendarToken={googleCalendarToken}
+            handleGoogleAuthClick={handleGoogleAuthClick}
+            googleCalendarError={googleCalendarError}
+            loadingGoogleCalendarEvents={loadingGoogleCalendarEvents}
+          />
+        );
       default:
         return (
           <div className="p-6 flex items-center justify-center h-full">

--- a/src/components/ClaudeAssistant.jsx
+++ b/src/components/ClaudeAssistant.jsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { MessageCircle, Users } from 'lucide-react';
+
+const ClaudeAssistant = () => (
+  <div className="p-6 h-full flex flex-col">
+    <div className="flex items-center justify-between mb-6">
+      <h2 className="text-2xl font-bold text-gray-900">Claude Assistant</h2>
+      <div className="flex items-center space-x-2 text-sm text-gray-600">
+        <div className="w-2 h-2 bg-green-500 rounded-full"></div>
+        <span>Online</span>
+      </div>
+    </div>
+
+    <div className="flex-1 bg-white rounded-xl border p-4 mb-6 overflow-y-auto">
+      <div className="space-y-4">
+        <div className="flex items-start space-x-3">
+          <div className="w-8 h-8 bg-blue-500 rounded-full flex items-center justify-center">
+            <MessageCircle className="w-4 h-4 text-white" />
+          </div>
+          <div className="flex-1">
+            <p className="text-gray-900">Hello! I'm your Claude assistant. I can help you with:</p>
+            <ul className="mt-2 text-sm text-gray-600 list-disc list-inside space-y-1">
+              <li>Planning your weekly schedule and optimizing your time</li>
+              <li>Suggesting recipes based on your dietary preferences</li>
+              <li>Creating workout plans and tracking fitness goals</li>
+              <li>Managing tasks and setting reminders</li>
+              <li>Analyzing your habits and providing insights</li>
+            </ul>
+          </div>
+        </div>
+
+        <div className="flex items-start space-x-3">
+          <div className="w-8 h-8 bg-gray-300 rounded-full flex items-center justify-center">
+            <Users className="w-4 h-4 text-gray-600" />
+          </div>
+          <div className="flex-1 bg-gray-50 rounded-lg p-3">
+            <p className="text-gray-900">Can you suggest a healthy meal plan for this week that takes less than 30 minutes to prepare?</p>
+          </div>
+        </div>
+
+        <div className="flex items-start space-x-3">
+          <div className="w-8 h-8 bg-blue-500 rounded-full flex items-center justify-center">
+            <MessageCircle className="w-4 h-4 text-white" />
+          </div>
+          <div className="flex-1">
+            <p className="text-gray-900">I'd be happy to help! Based on your recipe app data, here are some quick, healthy options:</p>
+            <div className="mt-2 space-y-2">
+              <div className="bg-blue-50 p-3 rounded-lg">
+                <p className="font-medium text-blue-900">Monday: Chicken Teriyaki Bowl</p>
+                <p className="text-sm text-blue-600">25 min • 420 cal • High protein</p>
+              </div>
+              <div className="bg-blue-50 p-3 rounded-lg">
+                <p className="font-medium text-blue-900">Tuesday: Salmon & Quinoa</p>
+                <p className="text-sm text-blue-600">30 min • 380 cal • Omega-3 rich</p>
+              </div>
+            </div>
+            <p className="mt-2 text-sm text-gray-600">Would you like me to add these to your weekly planner?</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div className="flex items-center space-x-3">
+      <input
+        type="text"
+        placeholder="Ask Claude anything about your schedule, workouts, or nutrition..."
+        className="flex-1 px-4 py-3 border rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+      />
+      <button className="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700">
+        Send
+      </button>
+    </div>
+  </div>
+);
+
+export default ClaudeAssistant;

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import { Calendar, CheckSquare, MessageCircle, ChevronLeft, ChevronRight } from 'lucide-react';
+import DeepnotesEditor from 'deepnotes-editor';
+import 'deepnotes-editor/dist/deepnotes-editor.css';
+
+const Dashboard = ({
+  selectedDate,
+  setSelectedDate,
+  showDatePicker,
+  setShowDatePicker,
+  tasks,
+  getTasksForDate,
+  scratchpadContent,
+  setScratchpadContent,
+  handleTaskCompletionToggle
+}) => {
+  const navigateDay = (direction) => {
+    const newDate = new Date(selectedDate);
+    newDate.setDate(selectedDate.getDate() + direction);
+    setSelectedDate(newDate);
+  };
+
+  const formatSelectedDate = () => {
+    const today = new Date();
+    const yesterday = new Date(today);
+    yesterday.setDate(today.getDate() - 1);
+    const tomorrow = new Date(today);
+    tomorrow.setDate(today.getDate() + 1);
+
+    if (selectedDate.toDateString() === today.toDateString()) return 'Today';
+    if (selectedDate.toDateString() === yesterday.toDateString()) return 'Yesterday';
+    if (selectedDate.toDateString() === tomorrow.toDateString()) return 'Tomorrow';
+    return selectedDate.toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' });
+  };
+
+  const dayTasks = getTasksForDate(selectedDate);
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="bg-white rounded-xl p-4 shadow-sm border">
+        <div className="flex items-center justify-between">
+          <button onClick={() => navigateDay(-1)} className="flex items-center px-3 py-2 text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-lg transition-colors">
+            <ChevronLeft className="w-5 h-5" />
+          </button>
+          <div className="flex items-center space-x-3">
+            <h1 className="text-2xl font-bold text-gray-900">{formatSelectedDate()}</h1>
+            <button onClick={() => setShowDatePicker(!showDatePicker)} className="p-2 text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-lg transition-colors" title="Open date picker">
+              <Calendar className="w-5 h-5" />
+            </button>
+          </div>
+          <button onClick={() => navigateDay(1)} className="flex items-center px-3 py-2 text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-lg transition-colors">
+            <ChevronRight className="w-5 h-5" />
+          </button>
+        </div>
+        {showDatePicker && (
+          <div className="mt-4 flex justify-center">
+            <input
+              type="date"
+              value={selectedDate.toISOString().split('T')[0]}
+              onChange={(e) => {
+                setSelectedDate(new Date(e.target.value));
+                setShowDatePicker(false);
+              }}
+              className="px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            />
+          </div>
+        )}
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div className="bg-white rounded-xl p-6 shadow-sm border">
+          <div className="flex items-center justify-between mb-4">
+            <h3 className="font-semibold text-gray-900 flex items-center">
+              <CheckSquare className="w-5 h-5 mr-2 text-blue-600" />
+              Tasks
+            </h3>
+            <span className="text-sm text-gray-500">{dayTasks.length} tasks</span>
+          </div>
+          <div className="space-y-3 min-h-[200px] max-h-[300px] overflow-y-auto">
+            {dayTasks.length === 0 ? (
+              <div className="flex items-center justify-center h-24 text-gray-500 bg-gray-50 rounded-lg border-2 border-dashed">
+                <div className="text-center">
+                  <CheckSquare className="w-8 h-8 mx-auto mb-2 text-gray-400" />
+                  <p className="text-sm">No tasks for this day</p>
+                </div>
+              </div>
+            ) : (
+              dayTasks.map(task => (
+                <div key={task.id} className="p-3 bg-blue-50 rounded-lg border border-blue-200">
+                  <div className="flex items-start">
+                    <input
+                      type="checkbox"
+                      className="mr-3 mt-1 rounded"
+                      checked={task.completed}
+                      onChange={() => handleTaskCompletionToggle(task.id, task.completed)}
+                    />
+                    <div>
+                      <p className={`font-medium ${task.completed ? 'line-through text-gray-500' : 'text-blue-900'}`}>{task.content || task.title}</p>
+                    </div>
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+
+        <div className="bg-white rounded-xl p-6 shadow-sm border">
+          <div className="flex items-center justify-between mb-4">
+            <h3 className="font-semibold text-gray-900 flex items-center">
+              <MessageCircle className="w-5 h-5 mr-2 text-purple-600" />
+              Scratchpad
+            </h3>
+            <span className="text-sm text-gray-500">Notes for {formatSelectedDate()}</span>
+          </div>
+          <div className="min-h-[200px] border rounded-lg p-4 bg-gray-50">
+            <DeepnotesEditor
+              content={scratchpadContent}
+              onChange={setScratchpadContent}
+              placeholder="Start typing your notes, ideas, or reminders..."
+              className="min-h-[160px] w-full border-none bg-transparent focus:outline-none"
+              style={{ lineHeight: 'normal', display: 'flex', alignItems: 'center' }}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Dashboard;

--- a/src/components/EnhancedDateInput.jsx
+++ b/src/components/EnhancedDateInput.jsx
@@ -1,0 +1,64 @@
+import React from 'react';
+
+const EnhancedDateInput = ({ value, onChange, placeholder, mode, onModeChange }) => {
+  const handleDateChange = (e) => {
+    onChange(e.target.value);
+  };
+
+  const handleModeToggle = () => {
+    onModeChange(mode === 'natural' ? 'picker' : 'natural');
+  };
+
+  const formatDateForInput = (dateValue) => {
+    if (!dateValue) return '';
+    if (mode === 'picker') {
+      const date = new Date(dateValue);
+      if (!isNaN(date.getTime())) {
+        return date.toISOString().split('T')[0];
+      }
+    }
+    return dateValue;
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <label className="block text-gray-700 text-sm font-bold">
+          Due Date
+        </label>
+        <button
+          type="button"
+          onClick={handleModeToggle}
+          className="text-xs text-blue-600 hover:text-blue-800"
+        >
+          {mode === 'natural' ? 'Use Date Picker' : 'Use Natural Language'}
+        </button>
+      </div>
+
+      {mode === 'natural' ? (
+        <input
+          type="text"
+          className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+          value={value}
+          onChange={handleDateChange}
+          placeholder={placeholder || 'e.g., today, tomorrow, next monday, 2024-12-31'}
+        />
+      ) : (
+        <input
+          type="date"
+          className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+          value={formatDateForInput(value)}
+          onChange={handleDateChange}
+        />
+      )}
+
+      <div className="text-xs text-gray-500">
+        {mode === 'natural'
+          ? 'Try: today, tomorrow, next monday, in 2 weeks, 2024-12-31'
+          : 'Select a date from the calendar'}
+      </div>
+    </div>
+  );
+};
+
+export default EnhancedDateInput;

--- a/src/components/Settings.jsx
+++ b/src/components/Settings.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+
+const Settings = ({
+  todoistToken,
+  setTodoistToken,
+  handleSaveTodoistToken,
+  todoistError,
+  googleCalendarToken,
+  handleGoogleAuthClick,
+  googleCalendarError,
+  loadingGoogleCalendarEvents
+}) => (
+  <div className="p-6">
+    <h2 className="text-2xl font-bold text-gray-900 mb-6">Settings</h2>
+    <div className="bg-white rounded-xl p-6 shadow-sm border mb-6">
+      <h3 className="font-semibold text-gray-900 mb-4">Todoist Integration</h3>
+      <p className="text-gray-600 mb-4">Enter your Todoist API token to sync your tasks.</p>
+      <div className="flex items-end space-x-3">
+        <input
+          type="text"
+          placeholder="Your Todoist API Token"
+          className="flex-1 px-4 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          value={todoistToken}
+          onChange={(e) => setTodoistToken(e.target.value)}
+        />
+        <button
+          onClick={handleSaveTodoistToken}
+          className="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
+        >
+          Save Token
+        </button>
+      </div>
+      {todoistError && <p className="text-red-500 mt-2">Error: {todoistError.message}</p>}
+      {todoistToken && !todoistError && (
+        <p className="text-green-600 mt-2">Todoist token saved and tasks fetched successfully!</p>
+      )}
+    </div>
+
+    <div className="bg-white rounded-xl p-6 shadow-sm border">
+      <h3 className="font-semibold text-gray-900 mb-4">Google Calendar Integration</h3>
+      <p className="text-gray-600 mb-4">Connect your Google Calendar to display events in the planner.</p>
+      <div className="flex items-end space-x-3">
+        <button
+          onClick={handleGoogleAuthClick}
+          className="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
+          disabled={loadingGoogleCalendarEvents}
+        >
+          {loadingGoogleCalendarEvents ? 'Connecting...' : 'Connect Google Calendar'}
+        </button>
+      </div>
+      {googleCalendarError && <p className="text-red-500 mt-2">Error: {googleCalendarError.message}</p>}
+      {googleCalendarToken && !googleCalendarError && (
+        <p className="text-green-600 mt-2">Google Calendar connected and events fetched successfully!</p>
+      )}
+    </div>
+  </div>
+);
+
+export default Settings;

--- a/src/components/TasksView.jsx
+++ b/src/components/TasksView.jsx
@@ -1,0 +1,311 @@
+import React from 'react';
+import { Plus } from 'lucide-react';
+import EnhancedDateInput from './EnhancedDateInput';
+import { getFilteredTasks, getSortedTasks, getGroupedTasks, toggleFilter } from '../utils/taskUtils';
+import { isTaskOverdue, isTaskDueToday, isTaskDueThisWeek } from '../utils/dateUtils';
+
+const TasksView = (props) => {
+  const {
+    tasks,
+    todoistToken,
+    loadingTodoistTasks,
+    todoistError,
+    fetchTodoistTasks,
+    setShowAddTaskModal,
+    showAddTaskModal,
+    newTaskContent,
+    setNewTaskContent,
+    newTaskPriority,
+    setNewTaskPriority,
+    newTaskDueDate,
+    setNewTaskDueDate,
+    newTaskDueDateMode,
+    setNewTaskDueDateMode,
+    handleAddTask,
+    handleDeleteTask,
+    handleTaskCompletionToggle,
+    setEditingTask,
+    setShowEditTaskModal,
+    activeFilters,
+    setActiveFilters,
+    sortBy,
+    setSortBy,
+    groupBy,
+    setGroupBy,
+    selectedProjects,
+    setSelectedProjects,
+    availableProjects
+  } = props;
+
+  const filteredTasks = getFilteredTasks(tasks, activeFilters, selectedProjects);
+  const sortedTasks = getSortedTasks(filteredTasks, sortBy);
+  const groupedTasks = getGroupedTasks(sortedTasks, groupBy);
+
+  return (
+    <div className="p-6">
+      <div className="flex items-center justify-between mb-6">
+        <h2 className="text-2xl font-bold text-gray-900">Tasks</h2>
+        <div className="flex space-x-2">
+          <button
+            onClick={() => fetchTodoistTasks(todoistToken)}
+            className="px-4 py-2 bg-gray-200 text-gray-800 rounded-lg hover:bg-gray-300"
+            disabled={loadingTodoistTasks}
+          >
+            {loadingTodoistTasks ? 'Syncing...' : 'Sync Now'}
+          </button>
+          <button
+            onClick={() => setShowAddTaskModal(true)}
+            className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
+          >
+            <Plus className="w-4 h-4 mr-2 inline" />
+            Add Task
+          </button>
+        </div>
+      </div>
+
+      {/* Filter, Sort, and Group Controls */}
+      <div className="bg-white rounded-xl p-4 shadow-sm border mb-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
+          {/* Sort Controls */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">Sort By</label>
+            <select
+              value={sortBy}
+              onChange={(e) => setSortBy(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="default">Default Order</option>
+              <option value="date">Due Date</option>
+              <option value="priority">Priority</option>
+              <option value="alphabetical">Alphabetical</option>
+            </select>
+          </div>
+
+          {/* Group Controls */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">Group By</label>
+            <select
+              value={groupBy}
+              onChange={(e) => setGroupBy(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="none">No Grouping</option>
+              <option value="date">Due Date</option>
+              <option value="priority">Priority</option>
+              <option value="project">Project</option>
+              <option value="label">Label</option>
+            </select>
+          </div>
+        </div>
+
+        {/* Quick Filter Buttons */}
+        <div className="space-y-4">
+          <div>
+            <span className="text-sm font-medium text-gray-700 mb-2 block">Quick Filters:</span>
+            <div className="flex flex-wrap gap-2">
+              {[
+                { key: 'all', label: 'All', count: tasks.filter(t => !t.project_name || t.project_name.toLowerCase() !== 'shopping list').length },
+                { key: 'today', label: 'Today', count: tasks.filter(t => isTaskDueToday(t)).length },
+                { key: 'week', label: 'This Week', count: tasks.filter(t => isTaskDueThisWeek(t)).length },
+                { key: 'overdue', label: 'Overdue', count: tasks.filter(t => isTaskOverdue(t)).length },
+                { key: 'bridge_club', label: 'Bridge Club', count: tasks.filter(t => t.project_name && t.project_name.toLowerCase().includes('bridge club')).length },
+                { key: 'home', label: 'Home', count: tasks.filter(t => t.project_name && t.project_name.toLowerCase() === 'home').length },
+                { key: 'cooking', label: 'Cooking', count: tasks.filter(t => t.project_name && t.project_name.toLowerCase() === 'meal_planning').length }
+              ].map(filter => (
+                <button
+                  key={filter.key}
+                  onClick={(e) => toggleFilter(filter.key, e)}
+                  className={`px-2 py-1 rounded-full text-xs transition-colors ${
+                    activeFilters.has(filter.key)
+                      ? 'bg-blue-600 text-white'
+                      : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                  }`}
+                >
+                  {filter.label} ({filter.count})
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Active Filters Summary */}
+          {(activeFilters.size > 1 || selectedProjects.size > 0) && (
+            <div className="pt-2 border-t">
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-medium text-gray-700">Active Filters:</span>
+                <button
+                  onClick={() => {
+                    setActiveFilters(new Set(['all']));
+                    setSelectedProjects(new Set());
+                  }}
+                  className="text-sm text-blue-600 hover:text-blue-800"
+                >
+                  Clear All
+                </button>
+              </div>
+              <div className="flex flex-wrap gap-1 mt-2">
+                {Array.from(activeFilters).filter(f => f !== 'all').map(filter => (
+                  <span key={filter} className="px-2 py-1 bg-blue-100 text-blue-800 rounded text-xs">
+                    {filter}
+                  </span>
+                ))}
+                {Array.from(selectedProjects).map(projectId => (
+                  <span key={projectId} className="px-2 py-1 bg-green-100 text-green-800 rounded text-xs">
+                    {availableProjects.find(p => p.id === projectId)?.name || projectId}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Task Groups */}
+      <div className="space-y-6">
+        {loadingTodoistTasks && <p>Loading tasks...</p>}
+        {todoistError && <p className="text-red-500">Error: {todoistError.message}</p>}
+        {!loadingTodoistTasks && tasks.length === 0 && !todoistError && (
+          <p className="text-gray-600">No tasks found. Add a new task or check your Todoist integration settings.</p>
+        )}
+
+        {!loadingTodoistTasks && tasks.length > 0 && Object.entries(groupedTasks).map(([groupName, groupTasks]) => (
+          <div key={groupName} className="space-y-3">
+            {groupBy !== 'none' && (
+              <div className="flex items-center">
+                <h3 className="text-lg font-semibold text-gray-900">{groupName}</h3>
+                <span className="ml-2 px-2 py-1 text-xs bg-gray-100 text-gray-600 rounded-full">
+                  {groupTasks.length}
+                </span>
+              </div>
+            )}
+
+            {groupTasks.map(task => (
+              <div key={task.id} className="bg-white rounded-xl p-4 shadow-sm border flex items-center justify-between hover:shadow-md transition-shadow">
+                <div className="flex items-center">
+                  <input
+                    type="checkbox"
+                    className="mr-3 rounded"
+                    checked={task.completed}
+                    onChange={() => handleTaskCompletionToggle(task.id, task.completed)}
+                  />
+                  <div>
+                    <p className={`font-medium ${task.completed ? 'line-through text-gray-500' : 'text-gray-900'}`}>
+                      {task.content || task.title}
+                    </p>
+                    <div className="flex items-center text-xs text-gray-500 mt-1 space-x-2">
+                      {task.priority && (
+                        <span className={`px-2 py-1 rounded-full ${
+                          task.priority === 4 ? 'bg-red-100 text-red-600' :
+                          task.priority === 3 ? 'bg-yellow-100 text-yellow-600' :
+                          task.priority === 2 ? 'bg-green-100 text-green-600' :
+                          'bg-gray-100 text-gray-600'
+                        }`}>P{task.priority}</span>
+                      )}
+                      {task.project_name && (
+                        <span className="px-2 py-1 bg-blue-100 text-blue-600 rounded-full">
+                          {task.project_name.toLowerCase().includes('bridge club') ? 'Bridge Club' : task.project_name}
+                        </span>
+                      )}
+                      {task.labels && task.labels.length > 0 && task.labels.map(label => (
+                        <span key={label} className="px-2 py-1 bg-purple-100 text-purple-600 rounded-full">
+                          @{label}
+                        </span>
+                      ))}
+                      {task.due && (
+                        <span className={`px-2 py-1 rounded-full ${
+                          isTaskOverdue(task) ? 'bg-red-100 text-red-600' :
+                          isTaskDueToday(task) ? 'bg-orange-100 text-orange-600' :
+                          'bg-gray-100 text-gray-600'
+                        }`}>
+                          {isTaskDueToday(task) ? 'Today' : isTaskOverdue(task) ? 'Overdue' : new Date(task.due).toLocaleDateString()}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </div>
+                <div className="flex items-center space-x-2">
+                  {task.source === 'todoist' && (
+                    <>
+                      <button
+                        onClick={() => handleDeleteTask(task.id)}
+                        className="p-1 rounded-full hover:bg-gray-200 text-red-500"
+                        title="Delete Task"
+                      >
+                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="lucide lucide-trash-2"><path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/><line x1="10" x2="10" y1="11" y2="17"/><line x1="14" x2="14" y1="11" y2="17"/></svg>
+                      </button>
+                      <button
+                        onClick={() => {
+                          setEditingTask(task);
+                          setShowEditTaskModal(true);
+                        }}
+                        className="p-1 rounded-full hover:bg-gray-200 text-blue-500"
+                        title="Edit Task"
+                      >
+                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="lucide lucide-edit"><path d="M22 13.0476V22H2V2h10.0476"/><path d="M17.477 3.35146 14.07 6.75841"/><path d="M14.07 6.75841 12.042 4.73045"/><path d="M12.042 4.73045 15.449 1.3235"/><path d="M15.449 1.3235 17.477 3.35146"/><path d="M17.477 3.35146 20.884 6.75841"/><path d="M20.884 6.75841 18.856 8.78637"/><path d="M18.856 8.78637 15.449 5.37941"/><path d="M15.449 5.37941 17.477 3.35146Z"/></svg>
+                      </button>
+                    </>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+
+      {showAddTaskModal && (
+        <div className="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full flex items-center justify-center">
+          <div className="bg-white p-8 rounded-lg shadow-xl max-w-md w-full">
+            <h3 className="text-xl font-bold mb-4">Add New Todoist Task</h3>
+            <div className="mb-4">
+              <label htmlFor="taskContent" className="block text-gray-700 text-sm font-bold mb-2">Task Content</label>
+              <input
+                type="text"
+                id="taskContent"
+                className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+                value={newTaskContent}
+                onChange={(e) => setNewTaskContent(e.target.value)}
+                placeholder="e.g., Buy groceries"
+              />
+            </div>
+            <div className="mb-4">
+              <label htmlFor="taskPriority" className="block text-gray-700 text-sm font-bold mb-2">Priority (1-4, 4 is highest)</label>
+              <input
+                type="number"
+                id="taskPriority"
+                className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+                value={newTaskPriority}
+                onChange={(e) => setNewTaskPriority(parseInt(e.target.value))}
+                min="1"
+                max="4"
+              />
+            </div>
+            <div className="mb-6">
+              <EnhancedDateInput
+                value={newTaskDueDate}
+                onChange={setNewTaskDueDate}
+                mode={newTaskDueDateMode}
+                onModeChange={setNewTaskDueDateMode}
+                placeholder="e.g., today, tomorrow, next monday"
+              />
+            </div>
+            <div className="flex justify-end space-x-4">
+              <button
+                onClick={() => setShowAddTaskModal(false)}
+                className="bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleAddTask}
+                className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
+              >
+                Add Task
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TasksView;

--- a/src/components/WeeklyPlanner.jsx
+++ b/src/components/WeeklyPlanner.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { CheckSquare } from 'lucide-react';
+import { formatWeekRange } from '../utils/dateUtils';
+
+const WeeklyPlanner = ({
+  currentWeekStart,
+  navigateWeek,
+  weekDates,
+  getTasksForDate
+}) => {
+  return (
+    <div className="p-6">
+      <div className="bg-white rounded-xl p-4 shadow-sm border mb-6 space-y-4">
+        <div className="flex items-center justify-between">
+          <button
+            onClick={() => navigateWeek(-1)}
+            className="flex items-center px-3 py-2 text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-lg transition-colors"
+          >
+            Previous Week
+          </button>
+          <div className="text-center">
+            <h2 className="text-xl font-semibold text-gray-900">{formatWeekRange(currentWeekStart)}</h2>
+          </div>
+          <button
+            onClick={() => navigateWeek(1)}
+            className="flex items-center px-3 py-2 text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-lg transition-colors"
+          >
+            Next Week
+          </button>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-7 gap-4">
+        {weekDates.map(date => {
+          const tasks = getTasksForDate(date);
+          return (
+            <div key={date.toISOString()} className="bg-white rounded-lg p-3 space-y-2 shadow-sm border">
+              <h3 className="text-sm font-semibold text-gray-900 text-center">
+                {date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })}
+              </h3>
+              <div className="space-y-1">
+                {tasks.length === 0 ? (
+                  <p className="text-xs text-gray-500 text-center">No tasks</p>
+                ) : (
+                  tasks.map(task => (
+                    <div key={task.id} className="flex items-center text-xs bg-gray-50 rounded px-2 py-1">
+                      <CheckSquare className="w-3 h-3 mr-1" />
+                      <span className="truncate">{task.content || task.title}</span>
+                    </div>
+                  ))
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default WeeklyPlanner;


### PR DESCRIPTION
## Summary
- create Dashboard, WeeklyPlanner, TasksView, Settings and ClaudeAssistant components
- add reusable EnhancedDateInput component
- simplify `App.js` to use new view components

## Testing
- `npm test --silent`
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_e_68657398133c832bb5a1058c8775ba2f