### PR TITLE
Add express backend and unify Claude key

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,51 +1,41 @@
 # Life Dashboard
 
-A React-based dashboard for integrating Google Calendar and Todoist tasks.
+Life Dashboard is a React application that centralizes tasks, events, workouts and meals into a single planning interface. It integrates with Todoist, Google Calendar and an optional Claude AI assistant.
 
 ## Environment Variables
 
-The application expects the following environment variables to be defined:
+Create a `.env` file in the project root and define:
 
-- `REACT_APP_GOOGLE_CLIENT_ID` – OAuth client ID for Google Calendar.
-- `REACT_APP_GOOGLE_API_KEY` – Google API key used for initializing the client.
-
-Create a `.env` file in the project root and add these keys before running the app:
-
-```bash
+```
 REACT_APP_GOOGLE_CLIENT_ID=your-google-client-id
 REACT_APP_GOOGLE_API_KEY=your-google-api-key
+# optional Anthropic API key
+REACT_APP_ANTHROPIC_API_KEY=your-anthropic-key
 ```
 
 ## Development
 
-Install dependencies and start the development server:
-
-```bash
-npm install
-npm start
-```
-=======
-Life Dashboard is a React application that centralizes tasks, events, workouts and meals into a single planning interface. It integrates with Todoist for task management and Google Calendar for event scheduling. Drag and drop support lets you plan your week by arranging tasks, recipes and workouts on a calendar.
-
-## Setup
-
-1. Install dependencies:
+1. Install dependencies
    ```bash
    npm install
    ```
-2. Start the development server:
+2. Start the backend API (serves `/api/claude`)
+   ```bash
+   npm run server
+   ```
+3. In another terminal start the React dev server
    ```bash
    npm start
    ```
 
-The application runs on port 3000 by default.
+The React server proxies unknown requests to the backend so `/api/claude` works during development.
 
 ## Major Features
 
-- **Todoist integration** – fetch, add and update tasks directly from your Todoist account.
-- **Google Calendar integration** – view, edit and delete events from your Google Calendar after connecting with an access token.
-- **Weekly planner** – drag tasks, recipes and workouts onto specific days of the week.
-- **Day planner** – see today's tasks, meals, workouts and a scratchpad powered by Deepnotes for quick notes.
-- **Filtering and sorting** – group tasks by date, project, priority or label and filter by custom categories.
+- **Todoist integration** – manage tasks directly from your Todoist account.
+- **Google Calendar integration** – view and update calendar events.
+- **Weekly planner** – drag tasks, recipes and workouts onto specific days.
+- **Day planner** – see today's tasks, meals, workouts and a scratchpad.
+- **Claude AI assistant** – conversational helper powered by Anthropic.
 
-Before using the integrations, update the API keys in `GoogleCalendarService.js` and supply your Todoist token in the settings screen.
+API keys can also be stored in the Settings screen.

--- a/package.json
+++ b/package.json
@@ -16,10 +16,12 @@
   },
   "scripts": {
     "start": "react-scripts start",
+    "server": "node server.js",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
+  "proxy": "http://localhost:5000",
   "eslintConfig": {
     "extends": [
       "react-app",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,82 @@
+const express = require('express');
+const app = express();
+
+app.use(express.json());
+
+// CORS middleware for development
+app.use((req, res, next) => {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, x-api-key');
+  if (req.method === 'OPTIONS') {
+    res.status(200).end();
+    return;
+  }
+  next();
+});
+
+app.post('/api/claude', async (req, res) => {
+  try {
+    const {
+      messages,
+      context,
+      systemPrompt,
+      model = 'claude-3-sonnet-20240229',
+      max_tokens = 2000,
+    } = req.body;
+    const apiKey = req.headers['x-api-key'];
+
+    if (!apiKey || !apiKey.startsWith('sk-ant-')) {
+      res
+        .status(400)
+        .json({ error: { message: 'Valid Claude API key required' } });
+      return;
+    }
+
+    console.log('Forwarding request to Claude API...');
+
+    const response = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01',
+      },
+      body: JSON.stringify({
+        model,
+        max_tokens,
+        system: systemPrompt || 'You are a helpful AI assistant.',
+        messages: messages.map((msg) => ({
+          role: msg.role,
+          content: msg.content,
+        })),
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      console.error('Claude API error:', errorText);
+      res.status(response.status).json({ error: { message: errorText } });
+      return;
+    }
+
+    const data = await response.json();
+    console.log('Claude API response received');
+
+    const content = data.content?.[0]?.text || '';
+    try {
+      const parsedContent = JSON.parse(content);
+      res.status(200).json(parsedContent);
+    } catch {
+      res.status(200).json({ response: content, actions: [], insights: [] });
+    }
+  } catch (error) {
+    console.error('API handler error:', error);
+    res.status(500).json({ error: { message: `Server error: ${error.message}` } });
+  }
+});
+
+const PORT = process.env.PORT || 5000;
+app.listen(PORT, () => {
+  console.log(`Backend listening on port ${PORT}`);
+});

--- a/src/App.js
+++ b/src/App.js
@@ -68,7 +68,7 @@ const LifeDashboardApp = () => {
   
   // Claude API integration state
   const [claudeApiKey, setClaudeApiKey] = useState(
-    localStorage.getItem("claudeApiKey") || ""
+    localStorage.getItem("claude_api_key") || ""
   );
   const [claudeApiError, setClaudeApiError] = useState(null);
   // Week start state - must be declared early since other functions depend on it
@@ -317,7 +317,7 @@ const LifeDashboardApp = () => {
 
   const handleSaveClaudeApiKey = () => {
     if (claudeApiKey.trim()) {
-      localStorage.setItem("claudeApiKey", claudeApiKey);
+      localStorage.setItem("claude_api_key", claudeApiKey);
       setClaudeApiError(null);
       // You can add validation here if needed
     } else {


### PR DESCRIPTION
## Summary
- add a simple Express server exposing `/api/claude`
- proxy dev requests to this server
- store Claude API key consistently as `claude_api_key`
- update documentation with backend instructions

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865a7bcca6c832b9176ba3f3ae9c594