### PR TITLE
Fix compile error in Dashboard

### DIFF
--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -18,7 +18,8 @@ function Dashboard({
   scheduledWorkouts = {},
   setScheduledWorkouts,
   selectedDate,
-  setSelectedDate
+  setSelectedDate,
+  setShowAddTaskModal
 }) {
 
 


### PR DESCRIPTION
## Summary
- accept setShowAddTaskModal as a prop for Dashboard

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686635d80014832b8ed4bd67b94cd786